### PR TITLE
Add elimination and lives tracking

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,11 @@ export default function App() {
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Croque Carotte</Text>
       <Board state={state} />
+      {state.players.map(p => (
+        <Text key={p.id} style={styles.text}>
+          {p.name}: {p.lives} lives {p.eliminated ? '(eliminated)' : ''}
+        </Text>
+      ))}
       {lastCard && <Text style={styles.text}>Last card: {lastCard}</Text>}
       {winner ? (
         <Text style={styles.text}>Winner: {winner}</Text>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -17,7 +17,9 @@ export function Board({ state }: Props) {
   const cols = 5;
 
   const renderCell = (index: number) => {
-    const playersHere = state.players.filter(p => p.position === index);
+    const playersHere = state.players.filter(
+      p => p.position === index && !p.eliminated,
+    );
     const isHole = state.holes.includes(index);
     return (
       <Cell key={index} hasHole={isHole}>

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -13,8 +13,8 @@ export class Game {
     // Two players: user and bot start at position 0 with some lives.
     this.deck = new CardDeck();
     const players: Player[] = [
-      { id: 0, name: 'You', position: 0, lives: startingLives },
-      { id: 1, name: 'Bot', position: 0, lives: startingLives },
+      { id: 0, name: 'You', position: 0, lives: startingLives, eliminated: false },
+      { id: 1, name: 'Bot', position: 0, lives: startingLives, eliminated: false },
     ];
     this.state = {
       boardSize,
@@ -42,10 +42,14 @@ export class Game {
         this.rotateCarrot();
         break;
     }
-    // Check win condition
-    if (player.position >= this.state.boardSize - 1) {
-      // Player reached the carrot at the top
+    // Check win condition by reaching the carrot
+    if (!player.eliminated && player.position >= this.state.boardSize - 1) {
       return { card, winner: player };
+    }
+    // Check if only one player remains
+    const remaining = this.state.players.filter(p => !p.eliminated);
+    if (remaining.length === 1) {
+      return { card, winner: remaining[0] };
     }
     this.nextTurn();
     return { card };
@@ -58,6 +62,9 @@ export class Game {
     if (this.state.holes.includes(player.position)) {
       player.lives -= 1;
       player.position = 0;
+      if (player.lives <= 0) {
+        player.eliminated = true;
+      }
     }
   }
 
@@ -68,13 +75,24 @@ export class Game {
       if (this.state.holes.includes(p.position)) {
         p.lives -= 1;
         p.position = 0;
+        if (p.lives <= 0) {
+          p.eliminated = true;
+        }
       }
     }
   }
 
   /** Switch active player. */
   private nextTurn() {
-    this.state.currentPlayer = (this.state.currentPlayer + 1) % this.state.players.length;
+    const total = this.state.players.length;
+    let next = (this.state.currentPlayer + 1) % total;
+    while (this.state.players[next].eliminated) {
+      next = (next + 1) % total;
+      if (next === this.state.currentPlayer) {
+        break; // all players eliminated (should be handled elsewhere)
+      }
+    }
+    this.state.currentPlayer = next;
   }
 
   /** Generate a random set of hole positions. */

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -12,6 +12,8 @@ export interface Player {
   position: number;
   /** Remaining lives. */
   lives: number;
+  /** Whether the player has been eliminated. */
+  eliminated: boolean;
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- mark players as eliminated when their lives run out
- skip eliminated players on next turn
- detect winner when all other players are eliminated
- show lives and elimination status in the UI

## Testing
- `npx tsc --noEmit` *(fails: prints help because no tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68408108a97883319c44360646eba86b