### PR TITLE
Add cross-platform Croque Carotte prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Node modules
+node_modules/
+
+# Expo/React Native
+.expo/
+.expo-shared/
+*.expo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Cache
+.env.local
+.cache/
+
+# macOS
+.DS_Store

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, Button, StyleSheet } from 'react-native';
+import { Game } from './src/game/Game';
+import { CardType } from './src/game/types';
+import { Board } from './src/components/Board';
+
+const game = new Game();
+
+export default function App() {
+  const [state, setState] = useState(game.state);
+  const [lastCard, setLastCard] = useState<CardType | null>(null);
+  const [winner, setWinner] = useState<string | null>(null);
+
+  const handleTurn = () => {
+    const result = game.takeTurn();
+    setState({ ...game.state });
+    setLastCard(result.card);
+    if (result.winner) {
+      setWinner(result.winner.name);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Croque Carotte</Text>
+      <Board state={state} />
+      {lastCard && <Text style={styles.text}>Last card: {lastCard}</Text>}
+      {winner ? (
+        <Text style={styles.text}>Winner: {winner}</Text>
+      ) : (
+        <Button title="Next turn" onPress={handleTurn} />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+  },
+  text: {
+    marginTop: 10,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # croque-carotte
+
+This repository contains a simple cross-platform implementation of the classic
+"Croque Carotte" board game. The game is written in **React Native** with
+**TypeScript** so it can be easily executed on both iOS and Android devices
+(using [Expo](https://expo.dev)). This project targets **Expo SDK&nbsp;53**, so
+make sure your Expo CLI and Expo Go app are up to date.
+
+## Running the app
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Ensure you have the Expo CLI installed (or run it with `npx`):
+   ```bash
+   npm install -g expo-cli # optional
+   ```
+3. Start the Expo development server:
+   ```bash
+   npx expo start
+   ```
+4. Use the Expo Go app on your iOS or Android device (or a simulator) to run
+   the game.
+
+### Troubleshooting
+
+If you see a `TypeScript: A tsconfig.json has been auto-generated` message the
+first time you run `expo start`, it's because the repository did not include a
+`tsconfig.json`. One has now been added. If the message persists you can safely
+delete the generated file and use the one provided in this repository.
+
+On some systems the Metro bundler may fail with an `EMFILE: too many open
+files` error. This usually means your OS is watching too many files. Installing
+[watchman](https://facebook.github.io/watchman/) and restarting the command
+generally resolves the issue. Alternatively, you can increase the allowed file
+watch limit (e.g. `ulimit -n 10000` on macOS/Linux) before running `npx expo start`.
+
+This implementation focuses on demonstrating the game logic and UI in a simple
+way. The main code lives in `App.tsx` and the files under `src/`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "croque-carotte",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^53.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,0 +1,47 @@
+// React Native component to display the game board and rabbits.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { GameState } from '../game/types';
+import { Cell } from './Cell';
+import { Rabbit } from './Rabbit';
+
+interface Props {
+  state: GameState;
+}
+
+/**
+ * Render the board as a grid of cells in an aerial view.
+ */
+export function Board({ state }: Props) {
+  // 5 columns grid layout
+  const cols = 5;
+
+  const renderCell = (index: number) => {
+    const playersHere = state.players.filter(p => p.position === index);
+    const isHole = state.holes.includes(index);
+    return (
+      <Cell key={index} hasHole={isHole}>
+        {playersHere.map(p => (
+          <Rabbit key={p.id} color={p.id === 0 ? '#ff0000' : '#0000ff'} />
+        ))}
+      </Cell>
+    );
+  };
+
+  // Build an array of cells to render.
+  const cells: JSX.Element[] = [];
+  for (let i = 0; i < state.boardSize; i++) {
+    cells.push(renderCell(i));
+  }
+
+  // Container arranges cells in rows.
+  return <View style={styles.container}>{cells}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    width: 5 * 50,
+  },
+});

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,0 +1,32 @@
+// Visual representation of a single board cell.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+interface Props {
+  hasHole: boolean;
+  children?: React.ReactNode;
+}
+
+/**
+ * Single cell on the board.
+ */
+export function Cell({ hasHole, children }: Props) {
+  return (
+    <View style={[styles.cell, hasHole && styles.hole]}> {children} </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    width: 50,
+    height: 50,
+    borderWidth: 1,
+    borderColor: '#333',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#a1d99b',
+  },
+  hole: {
+    backgroundColor: '#654321',
+  },
+});

--- a/src/components/Rabbit.tsx
+++ b/src/components/Rabbit.tsx
@@ -1,0 +1,19 @@
+// Small component representing a rabbit token.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+interface Props {
+  color: string;
+}
+
+export function Rabbit({ color }: Props) {
+  return <View style={[styles.rabbit, { backgroundColor: color }]} />;
+}
+
+const styles = StyleSheet.create({
+  rabbit: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+  },
+});

--- a/src/game/CardDeck.ts
+++ b/src/game/CardDeck.ts
@@ -1,0 +1,38 @@
+// Utility class representing the deck of cards used in the game.
+import { CardType } from './types';
+
+/** Simple deck with 4 copies of each card type. */
+export class CardDeck {
+  /** Current list of cards remaining in the deck. */
+  private cards: CardType[] = [];
+
+  constructor() {
+    this.reset();
+  }
+
+  /** Reshuffle the deck to its initial state. */
+  reset() {
+    this.cards = [];
+    // Add four copies of each card to the deck.
+    for (let i = 0; i < 4; i++) {
+      this.cards.push(CardType.Move1, CardType.Move2, CardType.Move3, CardType.Carrot);
+    }
+    this.shuffle();
+  }
+
+  /** Draw one card. Automatically reshuffles if empty. */
+  draw(): CardType {
+    if (this.cards.length === 0) {
+      this.reset();
+    }
+    return this.cards.pop() as CardType;
+  }
+
+  /** Fisher-Yates shuffle. */
+  private shuffle() {
+    for (let i = this.cards.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [this.cards[i], this.cards[j]] = [this.cards[j], this.cards[i]];
+    }
+  }
+}

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -1,0 +1,89 @@
+// Implementation of the game rules and player interactions.
+import { CardType, GameState, Player } from './types';
+import { CardDeck } from './CardDeck';
+
+/**
+ * Core game logic for Croque Carotte.
+ */
+export class Game {
+  state: GameState;
+  private deck: CardDeck; // Card deck providing random actions.
+
+  constructor(boardSize = 20, startingLives = 3) {
+    // Two players: user and bot start at position 0 with some lives.
+    this.deck = new CardDeck();
+    const players: Player[] = [
+      { id: 0, name: 'You', position: 0, lives: startingLives },
+      { id: 1, name: 'Bot', position: 0, lives: startingLives },
+    ];
+    this.state = {
+      boardSize,
+      holes: this.generateHoles(boardSize),
+      players,
+      currentPlayer: 0,
+    };
+  }
+
+  /** Main game loop for a single turn. */
+  takeTurn() {
+    const card = this.deck.draw();
+    const player = this.state.players[this.state.currentPlayer];
+    switch (card) {
+      case CardType.Move1:
+        this.advancePlayer(player, 1);
+        break;
+      case CardType.Move2:
+        this.advancePlayer(player, 2);
+        break;
+      case CardType.Move3:
+        this.advancePlayer(player, 3);
+        break;
+      case CardType.Carrot:
+        this.rotateCarrot();
+        break;
+    }
+    // Check win condition
+    if (player.position >= this.state.boardSize - 1) {
+      // Player reached the carrot at the top
+      return { card, winner: player };
+    }
+    this.nextTurn();
+    return { card };
+  }
+
+  /** Move player forward and handle holes. */
+  private advancePlayer(player: Player, steps: number) {
+    player.position = Math.min(player.position + steps, this.state.boardSize - 1);
+    // If the player lands on a hole, they fall and go back to start losing a life
+    if (this.state.holes.includes(player.position)) {
+      player.lives -= 1;
+      player.position = 0;
+    }
+  }
+
+  /** Change hole positions randomly. Any player on a new hole loses a life. */
+  private rotateCarrot() {
+    this.state.holes = this.generateHoles(this.state.boardSize);
+    for (const p of this.state.players) {
+      if (this.state.holes.includes(p.position)) {
+        p.lives -= 1;
+        p.position = 0;
+      }
+    }
+  }
+
+  /** Switch active player. */
+  private nextTurn() {
+    this.state.currentPlayer = (this.state.currentPlayer + 1) % this.state.players.length;
+  }
+
+  /** Generate a random set of hole positions. */
+  private generateHoles(size: number): number[] {
+    const holes: Set<number> = new Set();
+    while (holes.size < 4) {
+      const idx = Math.floor(Math.random() * (size - 2)) + 1; // avoid start and carrot
+      holes.add(idx);
+    }
+    return Array.from(holes);
+  }
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,22 @@
+export enum CardType {
+  Move1 = 'MOVE_1',
+  Move2 = 'MOVE_2',
+  Move3 = 'MOVE_3',
+  Carrot = 'CARROT',
+}
+
+export interface Player {
+  id: number;
+  name: string;
+  /** Current position on the board (0 is start). */
+  position: number;
+  /** Remaining lives. */
+  lives: number;
+}
+
+export interface GameState {
+  boardSize: number;
+  holes: number[];
+  players: Player[];
+  currentPlayer: number; // index in players array
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "jsx": "react-native",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- implement a simple React Native version of Croque Carotte
- add TypeScript game logic and UI components
- document how to run the game with Expo
- update Expo SDK requirement and add `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68407c0709648331b30682f702e5223c