### PR TITLE
Enhance UI with spiral board and deck

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,40 +1,79 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { SafeAreaView, View, Text, Button, StyleSheet } from 'react-native';
 import { Game } from './src/game/Game';
-import { CardType } from './src/game/types';
+import { CardType, GameState } from './src/game/types';
 import { Board } from './src/components/Board';
-
-const game = new Game();
+import { Deck } from './src/components/Deck';
 
 export default function App() {
-  const [state, setState] = useState(game.state);
+  const [phase, setPhase] = useState<'menu' | 'playing' | 'result'>('menu');
+  const [game, setGame] = useState<Game | null>(null);
+  const [state, setState] = useState<GameState | null>(null);
   const [lastCard, setLastCard] = useState<CardType | null>(null);
   const [winner, setWinner] = useState<string | null>(null);
 
+  const startGame = () => {
+    const g = new Game();
+    setGame(g);
+    setState({ ...g.state });
+    setLastCard(null);
+    setWinner(null);
+    setPhase('playing');
+  };
+
   const handleTurn = () => {
+    if (!game) return;
     const result = game.takeTurn();
     setState({ ...game.state });
     setLastCard(result.card);
     if (result.winner) {
-      setWinner(result.winner.name);
+      setWinner(result.winner.id === 0 ? 'You' : 'Bot');
+      setPhase('result');
     }
   };
+
+  useEffect(() => {
+    if (phase === 'playing' && game && game.state.currentPlayer === 1) {
+      const t = setTimeout(handleTurn, 1000);
+      return () => clearTimeout(t);
+    }
+  }, [state, phase]);
+
+  if (phase === 'menu') {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text style={styles.title}>Croque Carotte 🥕</Text>
+        <Button title="Start" onPress={startGame} />
+      </SafeAreaView>
+    );
+  }
+
+  if (phase === 'result') {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text style={styles.title}>{winner === 'You' ? 'You win 🥳' : 'You lose 😢'}</Text>
+        <Button title="Restart" onPress={startGame} />
+      </SafeAreaView>
+    );
+  }
+
+  if (!state) return null;
+
+  const current = game!.state.players[game!.state.currentPlayer];
 
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Croque Carotte</Text>
       <Board state={state} />
+      <View style={{ marginVertical: 20 }}>
+        {current.id === 0 && <Deck onDraw={handleTurn} />}
+      </View>
       {state.players.map(p => (
         <Text key={p.id} style={styles.text}>
           {p.name}: {p.lives} lives {p.eliminated ? '(eliminated)' : ''}
         </Text>
       ))}
       {lastCard && <Text style={styles.text}>Last card: {lastCard}</Text>}
-      {winner ? (
-        <Text style={styles.text}>Winner: {winner}</Text>
-      ) : (
-        <Button title="Next turn" onPress={handleTurn} />
-      )}
     </SafeAreaView>
   );
 }
@@ -51,5 +90,10 @@ const styles = StyleSheet.create({
   },
   text: {
     marginTop: 10,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,6 +1,6 @@
 // React Native component to display the game board and rabbits.
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { GameState } from '../game/types';
 import { Cell } from './Cell';
 import { Rabbit } from './Rabbit';
@@ -13,8 +13,35 @@ interface Props {
  * Render the board as a grid of cells in an aerial view.
  */
 export function Board({ state }: Props) {
-  // 5 columns grid layout
   const cols = 5;
+  const rows = Math.ceil(state.boardSize / cols);
+
+  const generateSnail = (r: number, c: number) => {
+    const order: number[] = [];
+    let top = 0,
+      bottom = r - 1,
+      left = 0,
+      right = c - 1;
+    while (top <= bottom && left <= right) {
+      for (let i = left; i <= right; i++) order.push(top * c + i);
+      top++;
+      for (let i = top; i <= bottom; i++) order.push(i * c + right);
+      right--;
+      if (top <= bottom) {
+        for (let i = right; i >= left; i--) order.push(bottom * c + i);
+        bottom--;
+      }
+      if (left <= right) {
+        for (let i = bottom; i >= top; i--) order.push(i * c + left);
+        left++;
+      }
+    }
+    return order;
+  };
+
+  const snail = generateSnail(rows, cols).slice(0, state.boardSize);
+
+  const last = snail[snail.length - 1];
 
   const renderCell = (index: number) => {
     const playersHere = state.players.filter(
@@ -26,17 +53,17 @@ export function Board({ state }: Props) {
         {playersHere.map(p => (
           <Rabbit key={p.id} color={p.id === 0 ? '#ff0000' : '#0000ff'} />
         ))}
+        {index === last && <Text style={{ fontSize: 24 }}>🥕</Text>}
       </Cell>
     );
   };
 
   // Build an array of cells to render.
   const cells: JSX.Element[] = [];
-  for (let i = 0; i < state.boardSize; i++) {
-    cells.push(renderCell(i));
+  for (const idx of snail) {
+    cells.push(renderCell(idx));
   }
 
-  // Container arranges cells in rows.
   return <View style={styles.container}>{cells}</View>;
 }
 

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -20,11 +20,13 @@ const styles = StyleSheet.create({
   cell: {
     width: 50,
     height: 50,
+    borderRadius: 25,
     borderWidth: 1,
     borderColor: '#333',
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: '#a1d99b',
+    margin: 2,
   },
   hole: {
     backgroundColor: '#654321',

--- a/src/components/Deck.tsx
+++ b/src/components/Deck.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  onDraw: () => void;
+}
+
+export function Deck({ onDraw }: Props) {
+  return (
+    <TouchableOpacity style={styles.deck} onPress={onDraw}>
+      <Text style={styles.emoji}>🎴</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  deck: {
+    width: 60,
+    height: 80,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+    elevation: 3,
+  },
+  emoji: { fontSize: 40 },
+});
+

--- a/src/components/Rabbit.tsx
+++ b/src/components/Rabbit.tsx
@@ -1,19 +1,17 @@
 // Small component representing a rabbit token.
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 interface Props {
   color: string;
 }
 
 export function Rabbit({ color }: Props) {
-  return <View style={[styles.rabbit, { backgroundColor: color }]} />;
+  return <Text style={[styles.rabbit, { color }]}>{'\uD83D\uDC30'}</Text>;
 }
 
 const styles = StyleSheet.create({
   rabbit: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
+    fontSize: 20,
   },
 });


### PR DESCRIPTION
## Summary
- overhauled `App` to include start menu and result screens
- board now rendered in a spiral layout with carrot emoji goal
- cells are circular
- rabbits shown as emoji
- add clickable deck component for drawing cards

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084f25e508331af7559e34e647ebf